### PR TITLE
git clone vundle时使用https协议

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -12,7 +12,7 @@ cd ~/ && git clone https://github.com/ma6174/vim.git
 mv ~/.vim ~/.vim_old -f
 mv ~/vim ~/.vim -f
 mv ~/.vim/.vimrc ~/ -f
-git clone http://github.com/gmarik/vundle.git ~/.vim/bundle/vundle
+git clone https://github.com/gmarik/vundle.git ~/.vim/bundle/vundle
 echo "ma6174正在努力为您安装bundle程序" > ma6174
 echo "安装完毕将自动退出" >> ma6174
 echo "请耐心等待" >> ma6174


### PR DESCRIPTION
`git clone http://github.com/gmarik/vundle.git` 时一直卡在 `Initialized empty Git repository in ...` 这里，改成https协议后可以正常完成，另外也可与前面的 `git clone https://github.com/ma6174/vim.git` 风格保持一致。
