### PR TITLE
修改java程序自动生成的内容

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -143,7 +143,7 @@ func SetTitle()
 		call append(line(".")+7, "")
 	endif
 "	if &filetype == 'java'
-"		call append(line(".")+6,"public class ".expand("%"))
+"		call append(line(".")+6,"public class ".strpart(expand("%d"),0,strlen(expand("%"))-5))
 "		call append(line(".")+7,"")
 "	endif
 	"新建文件后，自动定位到文件末尾


### PR DESCRIPTION
在写java时会遇到这种情况。我写一个类ABC.java。然后自动生成的内容是`public class ABC.java`但是实际上我们都知道应该生成的是`public class ABC`。所以我对.vimrc的146行做了修改。
测试的时候记得把Java部分的引号去掉，解除注释状态。
