### PR TITLE
增加.h头文件自动生成的内容

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -111,7 +111,7 @@ nmap tt :%s/\t/    /g<CR>
 """""新文件标题
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 "新建.c,.h,.sh,.java文件，自动插入文件头 
-autocmd BufNewFile *.cpp,*.c,*.sh,*.rb,*.java,*.py exec ":call SetTitle()" 
+autocmd BufNewFile *.cpp,*.[ch],*.sh,*.rb,*.java,*.py exec ":call SetTitle()" 
 ""定义函数SetTitle，自动插入文件头 
 func SetTitle() 
 	"如果文件类型为.sh文件 


### PR DESCRIPTION
一般的我们新建一个头文件，比如test.h，我们都会在文件内写上

``` c
#ifndef _TEST_H
#define _TEST_H
...
#endif
```

来方式多次包含。

> 其中_TEST_H有些人的习惯是写成TEST_H

之所以不写filetype=='h'，并且甚至改掉了filetype=='cpp'。是因为，我测试了下，如果写作filetype的形式，那么其实增加的h这段代码并没有生效，而是给h文件也自动添加了cpp的文件头。这个原因是vim把.h和cpp视作一种文件类型，这里的filetype相同是因为它们的语法是完全相同的。为了避免这个_bug_，我改成了判断文件后缀名的方式-----`expand("%:e")`。
